### PR TITLE
Build the web client as a container and publish it to GHCR

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -528,7 +528,7 @@ More detail, including how to diagnose flaky device runs, is in [`docs/testing.m
 
 ## Continuous integration
 
-[Cross-platform CI](workflows/ci.yml) runs on every push to `main`, every pull request, and on manual dispatch. It is split into four independently visible jobs so a failure points straight at the responsible platform:
+[Cross-platform CI](workflows/ci.yml) runs on every push to `main`, every pull request, and on manual dispatch. It is split into five independently visible jobs so a failure points straight at the responsible platform:
 
 | Job | Runner | Covers |
 | --- | --- | --- |
@@ -536,8 +536,23 @@ More detail, including how to diagnose flaky device runs, is in [`docs/testing.m
 | **iOS** | `macos-15` | `build-for-testing`, XCTest model coverage, XCUITest interaction and accessibility flows |
 | **Android JVM** | `ubuntu-latest` | ViewModel unit tests, Android lint, debug APK assembly |
 | **Android device** | `ubuntu-latest` + KVM | API 34 `pixel_6` emulator running the full Compose instrumentation suite |
+| **Docker** | `ubuntu-latest` | `linux/amd64` and `linux/arm64` image build, a smoke test that actually serves the game, and publication to GHCR |
 
 Web coverage reports, Xcode `.xcresult` bundles, Android lint and test reports, and the debug APK are uploaded as workflow artifacts — including on failure, which is usually when you need them most.
+
+### Container image
+
+The web client is published to the GitHub Container Registry on every push to `main`:
+
+```bash
+docker run --rm -p 8080:8080 ghcr.io/hoangsonww/2048-game:latest
+```
+
+The image is the Node runtime, the static files, and the same `scripts/serve-web.mjs` that `make serve` runs — no bundler, no framework, and nothing installed from npm, because the game has no runtime dependencies. It runs as an unprivileged user and carries a health check.
+
+**A pull request builds the image but never publishes it.** A fork's token cannot write packages, and pushing an image built from unreviewed code to a tag other people pull is not something a green check should do — so the publish step is reachable only from a commit that has already landed on a branch. Every pull request still proves the image builds on both architectures and that the running container serves the game, path traversal included.
+
+The iOS and Android clients are not containerized. Xcode is macOS-only and its licence forbids redistribution, and neither client is a server. That is a platform constraint, not a gap.
 
 Supporting automation: **dependency review** blocks pull requests that introduce known-vulnerable dependencies, and the **labeler** applies path-based platform labels automatically. Dependency updates are applied by hand — there is no bot opening upgrade pull requests. Issue forms, ownership rules, release-note categories, contribution guidance, support routing, and the security policy all live under `.github/`.
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -238,3 +238,118 @@ jobs:
           name: android-device-results
           path: Android-Version/Game2048/app/build/reports/androidTests/
           if-no-files-found: warn
+
+  docker:
+    name: Docker image build and publish
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    permissions:
+      contents: read
+      # Scoped to this job so the rest of the workflow keeps a read-only token.
+      packages: write
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      # arm64 is cross-built on an amd64 runner, which only works with binfmt
+      # handlers registered first.
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Buildx
+        uses: docker/setup-buildx-action@v3
+
+      # A pull request builds but never publishes. A fork's GITHUB_TOKEN cannot
+      # write packages anyway, and pushing an image built from unreviewed code
+      # to a tag other people pull is not something a green check should do.
+      - name: Decide whether this run publishes
+        id: mode
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            echo "push=false" >> "$GITHUB_OUTPUT"
+            echo "Pull request: building only, not publishing."
+          else
+            echo "push=true" >> "$GITHUB_OUTPUT"
+            echo "Branch build: publishing to GHCR."
+          fi
+
+      # GHCR rejects an uppercase path, and the repository name is mixed case.
+      - name: Derive the image name
+        id: image
+        run: echo "name=ghcr.io/$(echo '${{ github.repository }}' | tr '[:upper:]' '[:lower:]')" >> "$GITHUB_OUTPUT"
+
+      - name: Collect tags and labels
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ steps.image.outputs.name }}
+          tags: |
+            type=ref,event=branch
+            type=ref,event=pr
+            type=sha,format=long
+            type=raw,value=latest,enable={{is_default_branch}}
+
+      # Built and tested before anything is published, so a broken image cannot
+      # reach a tag someone else pulls. The publish step below reuses this
+      # layer cache, so proving it works costs little.
+      - name: Build the runner-architecture image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: false
+          load: true
+          tags: 2048-smoke-test:${{ github.sha }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Smoke test the image
+        run: |
+          set -Eeuo pipefail
+          docker run -d --name smoke -p 8080:8080 "2048-smoke-test:${{ github.sha }}"
+          for _ in $(seq 1 30); do
+            if curl -fsS http://127.0.0.1:8080/ >/dev/null 2>&1; then break; fi
+            sleep 1
+          done
+          echo "--- / must serve the game shell ---"
+          curl -fsS http://127.0.0.1:8080/ | grep -q "<title>"
+          echo "--- the engine and controller must be reachable ---"
+          curl -fsS http://127.0.0.1:8080/Web-Version/game-engine.js >/dev/null
+          curl -fsS http://127.0.0.1:8080/Web-Version/script.js >/dev/null
+          echo "--- discovery files and icons must be reachable ---"
+          curl -fsS http://127.0.0.1:8080/manifest.json >/dev/null
+          curl -fsS http://127.0.0.1:8080/images/favicon.svg >/dev/null
+          # --path-as-is stops curl collapsing the ".." itself, so the traversal
+          # actually reaches the server and its guard is what rejects it. The
+          # encoded form covers the decode-then-resolve path separately.
+          echo "--- a traversal must not escape the document root ---"
+          for path in "/../package.json" "/%2e%2e/package.json"; do
+            code="$(curl -s -o /dev/null -w '%{http_code}' --path-as-is "http://127.0.0.1:8080${path}")"
+            echo "  ${path} -> ${code}"
+            test "$code" != "200"
+          done
+          echo "--- the container must not run as root ---"
+          test "$(docker exec smoke id -u)" != "0"
+          echo "Smoke test passed."
+          docker rm -f smoke
+
+      - name: Log in to GHCR
+        if: steps.mode.outputs.push == 'true'
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # The server is plain Node reading static files, so both architectures are
+      # honest builds rather than an emulated guess. amd64 is a cache hit from
+      # the smoke-test build above.
+      - name: Build both architectures and publish
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: ${{ steps.mode.outputs.push == 'true' }}
+          platforms: linux/amd64,linux/arm64
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -319,8 +319,15 @@ jobs:
           curl -fsS http://127.0.0.1:8080/manifest.json >/dev/null
           curl -fsS http://127.0.0.1:8080/images/favicon.svg >/dev/null
           # --path-as-is stops curl collapsing the ".." itself, so the traversal
-          # actually reaches the server and its guard is what rejects it. The
-          # encoded form covers the decode-then-resolve path separately.
+          # reaches the server rather than being rewritten in the client.
+          #
+          # It is answered by the WHATWG URL parser, not by the resolve-and-
+          # compare guard in static-server.mjs: `new URL("/../x")` normalises
+          # the segment away, so `pathname` is already "/x" and the guard never
+          # fires. That makes the guard defence in depth against a future parser
+          # change rather than the active defence, which is worth knowing before
+          # anyone "simplifies" either half away. What this asserts is the
+          # outcome — a traversal never yields content — not the mechanism.
           echo "--- a traversal must not escape the document root ---"
           for path in "/../package.json" "/%2e%2e/package.json"; do
             code="$(curl -s -o /dev/null -w '%{http_code}' --path-as-is "http://127.0.0.1:8080${path}")"

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1326,7 +1326,14 @@ flowchart LR
     Push[push / PR / dispatch] --> Web[web · ubuntu]
     Push --> IOS[ios · macos-15]
     Push --> AJ[android-jvm · ubuntu]
+    Push --> DK[docker · ubuntu]
     AJ --> AD[android-device · ubuntu]
+
+    DK --> D1[build amd64 + arm64]
+    DK --> D2[smoke test a running container]
+    DK --> D3{"branch push?"}
+    D3 -- yes --> D4[publish to GHCR]
+    D3 -- "no, pull request" --> D5[build only, never publish]
 
     Web --> W1[npm audit]
     Web --> W2[syntax · repo · SEO validation]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,49 @@
+# Serves the 2048 web client.
+#
+# The web app is static — no bundler, no framework, no runtime dependencies.
+# `package.json` lists only devDependencies (c8, husky, playwright), so this
+# image installs nothing from npm: it is the Node runtime, the static files,
+# and the same `scripts/serve-web.mjs` that `make serve` runs locally. That
+# keeps what ships identical to what contributors test.
+#
+#   docker build -t 2048-game .
+#   docker run --rm -p 8080:8080 2048-game
+#
+# The iOS and Android clients are not in here. Both need vendor toolchains
+# that cannot run in this image, and neither is a server.
+
+FROM node:22-bookworm-slim
+
+# Tini reaps zombies and forwards signals, so `docker stop` reaches the
+# server's own SIGTERM handler instead of being papered over by a PID 1 that
+# ignores it.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends tini \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+# Copied as separate layers so an edit to the game does not invalidate the
+# server, and vice versa. `serve-web.mjs` resolves its document root as the
+# parent of `scripts/`, which is why the layout below mirrors the repository.
+COPY scripts/serve-web.mjs ./scripts/serve-web.mjs
+COPY scripts/lib/ ./scripts/lib/
+COPY images/ ./images/
+COPY Web-Version/ ./Web-Version/
+COPY index.html 404.html manifest.json robots.txt sitemap.xml humans.txt llms.txt llms-full.txt ./
+
+ENV NODE_ENV=production \
+    PORT=8080
+
+EXPOSE 8080
+
+# The base image ships an unprivileged `node` user. Nothing here needs root,
+# and the served tree is read-only to the process.
+USER node
+
+# Node 22 has a global fetch, so this needs no extra package.
+HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
+    CMD node -e "fetch('http://127.0.0.1:' + (process.env.PORT || 8080) + '/').then(r => process.exit(r.ok ? 0 : 1)).catch(() => process.exit(1))"
+
+ENTRYPOINT ["/usr/bin/tini", "--"]
+CMD ["node", "scripts/serve-web.mjs"]

--- a/scripts/validate-repository.mjs
+++ b/scripts/validate-repository.mjs
@@ -10,6 +10,7 @@ const requiredFiles = [
     ".dockerignore",
     ".devcontainer/devcontainer.json",
     ".devcontainer/devcontainer-lock.json",
+    "Dockerfile",
     ".github/PULL_REQUEST_TEMPLATE.md",
     ".pre-commit-config.yaml",
     "AGENTS.md",


### PR DESCRIPTION
## What

Adds a `Dockerfile` for the web client and a `docker` job to Cross-platform CI that builds it, proves the running container actually serves the game, and publishes it to the GitHub Container Registry.

```bash
docker run --rm -p 8080:8080 ghcr.io/hoangsonww/2048-game:latest
```

## The image

The Node runtime, the static files, and the same `scripts/serve-web.mjs` that `make serve` runs. Nothing is installed from npm — the game has no runtime dependencies, `package.json` lists only `c8`, `husky`, and `playwright` as devDependencies — so what ships is what contributors test. It runs as the unprivileged `node` user under tini, so `docker stop` reaches the server's own SIGTERM handler rather than being swallowed by a PID 1 that ignores it.

iOS and Android are not containerized: Xcode is macOS-only and its licence forbids redistribution, and neither client is a server.

## Publishing policy

**A pull request builds the image but never publishes it.** Two reasons, and both matter:

- A fork's `GITHUB_TOKEN` is read-only for packages, so it could not publish even if asked.
- Pushing an image built from unreviewed code to a tag other people pull is not something a green check should be able to do.

Publication is reachable only from a commit that has already landed on a branch. `packages: write` is scoped to this job alone; every other job keeps the workflow's read-only token.

## Job ordering

The smoke test runs **before** the publish step, not after, so an image that fails its own test cannot reach a tag. The publish reuses the smoke-test build's layer cache, so proving it works first costs very little.

## What the smoke test asserts

Against a container that is actually running:

| Check | Why |
| --- | --- |
| `/` serves the game shell | The document root resolves correctly |
| `game-engine.js`, `script.js` | The client can actually boot |
| `manifest.json`, `images/favicon.svg` | PWA and icon assets made it into the image |
| Process is not uid 0 | `USER node` is in effect |
| `/../package.json` and `/%2e%2e/package.json` refuse | A traversal never yields content |

The traversal check uses `curl --path-as-is`. Without it curl collapses the `..` client-side and the request never leaves as a traversal at all.

**Correction, from reading the first CI run rather than assuming.** Both traversals answered `404`, not the `403` the guard emits. The reason is that the WHATWG URL parser normalises the segment away — `new URL("/../package.json")` has `pathname === "/package.json"` before any of the server's own logic runs, and `%2e%2e` decodes to the same thing. So `static-server.mjs`'s resolve-and-compare guard **never fires** on a URL path; it is defence in depth against a future parser change, not the active defence.

The assertion is still worth having — it proves a traversal never yields content — but it asserts the outcome, not the mechanism, and the workflow comment now says so. My original comment claimed the guard was doing the rejecting, which was wrong.

## Architectures

`linux/amd64` and `linux/arm64`. The server is plain Node reading static files, so both are honest builds rather than an emulated guess. arm64 is cross-built on an amd64 runner, which needs QEMU binfmt handlers registered first — hence the `setup-qemu-action` step. amd64 is a cache hit from the smoke-test build.

## Also

`scripts/validate-repository.mjs` now requires the `Dockerfile`, matching how it already required `.dockerignore` — which, until now, guarded a file that did not exist.

Docs updated: the README gains a container section and the CI table becomes five jobs; `ARCHITECTURE.md`'s CI topology diagram gains the docker path including the publish/no-publish branch.

## Verification

`npm run check` passes. The Docker build itself was **not** verified locally — the local Docker daemon was blocked on a privileged-helper prompt, and this run is its first real build. That is deliberate and agreed, but worth stating plainly rather than implying local proof that does not exist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014jMpBbpzsiUWE21B9WvkRF