### PR TITLE
Build the Android client in a container and publish the SDK image

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -528,7 +528,7 @@ More detail, including how to diagnose flaky device runs, is in [`docs/testing.m
 
 ## Continuous integration
 
-[Cross-platform CI](workflows/ci.yml) runs on every push to `main`, every pull request, and on manual dispatch. It is split into five independently visible jobs so a failure points straight at the responsible platform:
+[Cross-platform CI](workflows/ci.yml) runs on every push to `main`, every pull request, and on manual dispatch. It is split into six independently visible jobs so a failure points straight at the responsible platform:
 
 | Job | Runner | Covers |
 | --- | --- | --- |
@@ -537,6 +537,7 @@ More detail, including how to diagnose flaky device runs, is in [`docs/testing.m
 | **Android JVM** | `ubuntu-latest` | ViewModel unit tests, Android lint, debug APK assembly |
 | **Android device** | `ubuntu-latest` + KVM | API 34 `pixel_6` emulator running the full Compose instrumentation suite |
 | **Docker** | `ubuntu-latest` | `linux/amd64` and `linux/arm64` image build, a smoke test that actually serves the game, and publication to GHCR |
+| **Android builder** | `ubuntu-latest` | `linux/amd64` SDK image, a containerized APK build with unit tests, and publication to GHCR |
 
 Web coverage reports, Xcode `.xcresult` bundles, Android lint and test reports, and the debug APK are uploaded as workflow artifacts — including on failure, which is usually when you need them most.
 
@@ -552,7 +553,24 @@ The image is the Node runtime, the static files, and the same `scripts/serve-web
 
 **A pull request builds the image but never publishes it.** A fork's token cannot write packages, and pushing an image built from unreviewed code to a tag other people pull is not something a green check should do — so the publish step is reachable only from a commit that has already landed on a branch. Every pull request still proves the image builds on both architectures and that the running container serves the game, path traversal included.
 
-The iOS and Android clients are not containerized. Xcode is macOS-only and its licence forbids redistribution, and neither client is a server. That is a platform constraint, not a gap.
+### Building Android without Android Studio
+
+The second image is a pinned JDK 17 and Android SDK 34 toolbox. Mount a checkout and build against it:
+
+```bash
+docker run --rm -v "$PWD:/src" -w /src/Android-Version/Game2048 \
+    ghcr.io/hoangsonww/2048-game-android:latest ./gradlew assembleDebug
+```
+
+Or build an APK in one shot, without starting a container:
+
+```bash
+docker buildx build -f Dockerfile.android --target apk --output out .
+```
+
+CI does both: it verifies the toolchain inside the image, then builds the debug APK *from* that image and runs the unit tests, so the published toolbox is proven to still build the project rather than merely to contain the binaries. The resulting APK is uploaded as a workflow artifact. `linux/amd64` only — Google ships the Android command-line tools as x86_64 Linux binaries, so an arm64 image would build cleanly and then fail at `aapt2` and `d8`.
+
+**iOS cannot be containerized, and this is not a gap that can be closed.** Docker containers are Linux; Xcode is macOS-only and has no Linux build; and Apple's licence forbids redistributing Xcode. Any one of those three is fatal on its own. iOS builds always require a macOS host.
 
 Supporting automation: **dependency review** blocks pull requests that introduce known-vulnerable dependencies, and the **labeler** applies path-based platform labels automatically. Dependency updates are applied by hand — there is no bot opening upgrade pull requests. Issue forms, ownership rules, release-note categories, contribution guidance, support routing, and the security policy all live under `.github/`.
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -360,3 +360,123 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+
+  docker-android:
+    name: Android builder image
+    runs-on: ubuntu-latest
+    timeout-minutes: 40
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Decide whether this run publishes
+        id: mode
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            echo "push=false" >> "$GITHUB_OUTPUT"
+            echo "Pull request: building only, not publishing."
+          else
+            echo "push=true" >> "$GITHUB_OUTPUT"
+            echo "Branch build: publishing to GHCR."
+          fi
+
+      - name: Collect tags and labels
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository_owner }}/2048-game-android
+          tags: |
+            type=ref,event=branch
+            type=ref,event=pr
+            type=sha,format=long
+            type=raw,value=latest,enable={{is_default_branch}}
+
+      # linux/amd64 only. Google ships the Android command-line tools and
+      # build-tools for Linux as x86_64 binaries, so an arm64 image would build
+      # cleanly and then fail at aapt2 and d8.
+      - name: Build the SDK image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: Dockerfile.android
+          target: sdk
+          push: false
+          load: true
+          platforms: linux/amd64
+          tags: 2048-android-sdk:${{ github.sha }}
+          cache-from: type=gha,scope=android
+          cache-to: type=gha,mode=max,scope=android
+
+      # An image that builds while missing a toolchain fails later and further
+      # from the cause. `bash -lc` is deliberate: a login shell resets PATH, so
+      # this also proves the /usr/local/bin symlinks are doing their job.
+      - name: Verify the toolchain inside the image
+        run: |
+          set -Eeuo pipefail
+          image="2048-android-sdk:${{ github.sha }}"
+          echo "--- Adoptium JDK 17, matching gradle-daemon-jvm.properties ---"
+          docker run --rm "$image" bash -lc 'java -version 2>&1 | head -1 | grep -q "17\."'
+          echo "--- the SDK entry points must resolve in a login shell ---"
+          docker run --rm "$image" bash -lc 'adb --version >/dev/null && sdkmanager --version >/dev/null'
+          echo "--- compileSdk 34 and its build-tools must be installed ---"
+          docker run --rm "$image" bash -lc 'test -d "$ANDROID_HOME/platforms/android-34"'
+          docker run --rm "$image" bash -lc 'test -d "$ANDROID_HOME/build-tools/34.0.0"'
+          echo "Toolchain verified."
+
+      # Proves the published image can actually build this project, not merely
+      # that the binaries exist. Runs the unit tests too, so a broken build
+      # cannot yield a green image. The APK lands on the runner via --output,
+      # with no container started and nothing published.
+      - name: Build the debug APK from the image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: Dockerfile.android
+          target: apk
+          platforms: linux/amd64
+          outputs: type=local,dest=android-apk
+          cache-from: type=gha,scope=android
+          cache-to: type=gha,mode=max,scope=android
+
+      - name: Confirm the APK is real
+        run: |
+          set -Eeuo pipefail
+          ls -la android-apk/
+          test -s android-apk/app-debug.apk
+          # An APK is a zip; a truncated or placeholder file is not.
+          unzip -l android-apk/app-debug.apk | grep -q AndroidManifest.xml
+          echo "APK verified: $(du -h android-apk/app-debug.apk | cut -f1)"
+
+      - name: Upload the containerized debug APK
+        uses: actions/upload-artifact@v4
+        with:
+          name: android-debug-apk-container-built
+          path: android-apk/app-debug.apk
+          if-no-files-found: error
+
+      - name: Log in to GHCR
+        if: steps.mode.outputs.push == 'true'
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Publish the SDK image
+        if: steps.mode.outputs.push == 'true'
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: Dockerfile.android
+          target: sdk
+          push: true
+          platforms: linux/amd64
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha,scope=android

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1327,7 +1327,13 @@ flowchart LR
     Push --> IOS[ios · macos-15]
     Push --> AJ[android-jvm · ubuntu]
     Push --> DK[docker · ubuntu]
+    Push --> DA[docker-android · ubuntu]
     AJ --> AD[android-device · ubuntu]
+
+    DA --> A1[SDK image · amd64 only]
+    DA --> A2[verify toolchain in a login shell]
+    DA --> A3[build APK + unit tests in the image]
+    DA --> A4[publish to GHCR on a branch push]
 
     DK --> D1[build amd64 + arm64]
     DK --> D2[smoke test a running container]

--- a/Dockerfile.android
+++ b/Dockerfile.android
@@ -1,0 +1,93 @@
+# Builds the Android client without Android Studio.
+#
+# The root Dockerfile serves the web client; this one builds the APK. They are
+# separate images because they have nothing in common — one is a Node runtime
+# holding static files, the other is a JDK and a 700MB SDK.
+#
+# The iOS client is deliberately absent and cannot be added. Xcode is
+# macOS-only, Docker containers are Linux, and Apple's licence forbids
+# redistributing Xcode — three independent blockers, any one of them fatal.
+# iOS builds always require a macOS host.
+#
+#   # toolbox: mount a checkout and build against it
+#   docker run --rm -v "$PWD:/src" -w /src/Android-Version/Game2048 \
+#       ghcr.io/hoangsonww/2048-game-android:latest ./gradlew assembleDebug
+#
+#   # one-shot: extract a freshly built debug APK
+#   docker buildx build -f Dockerfile.android --target apk --output out .
+
+# ---------------------------------------------------------------------------
+# The published image: a JDK and an Android SDK, and nothing project-specific.
+# Keeping sources out of this stage is what makes it reusable against any
+# checkout, including a contributor's dirty working tree.
+# ---------------------------------------------------------------------------
+FROM eclipse-temurin:17-jdk-jammy AS sdk
+
+# Pinned so a rebuild produces the same toolchain. These track
+# app/build.gradle.kts: compileSdk 34 and the matching build-tools.
+ARG ANDROID_COMMAND_LINE_TOOLS_VERSION=11076708
+ARG ANDROID_PLATFORM=android-34
+ARG ANDROID_BUILD_TOOLS=34.0.0
+
+ENV ANDROID_HOME=/opt/android-sdk \
+    ANDROID_SDK_ROOT=/opt/android-sdk \
+    GRADLE_USER_HOME=/opt/gradle
+
+ENV PATH=${ANDROID_HOME}/cmdline-tools/latest/bin:${ANDROID_HOME}/platform-tools:${PATH}
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        bash \
+        ca-certificates \
+        curl \
+        git \
+        unzip \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN mkdir -p "${ANDROID_HOME}/cmdline-tools" \
+    && curl --fail --location --retry 3 \
+        "https://dl.google.com/android/repository/commandlinetools-linux-${ANDROID_COMMAND_LINE_TOOLS_VERSION}_latest.zip" \
+        --output /tmp/android-tools.zip \
+    && unzip -q /tmp/android-tools.zip -d /tmp/android-tools \
+    && mv /tmp/android-tools/cmdline-tools "${ANDROID_HOME}/cmdline-tools/latest" \
+    && rm -rf /tmp/android-tools /tmp/android-tools.zip \
+    && yes | sdkmanager --licenses >/dev/null \
+    && sdkmanager "platform-tools" "platforms;${ANDROID_PLATFORM}" "build-tools;${ANDROID_BUILD_TOOLS}" >/dev/null \
+    # A login shell sources /etc/profile, which resets PATH and discards the
+    # ENV above. Symlinking into /usr/local/bin is what keeps these reachable
+    # from `docker run ... bash -lc`, which is how CI verifies the image.
+    && ln -s "${ANDROID_HOME}/platform-tools/adb" /usr/local/bin/adb \
+    && ln -s "${ANDROID_HOME}/cmdline-tools/latest/bin/sdkmanager" /usr/local/bin/sdkmanager \
+    && ln -s "${ANDROID_HOME}/cmdline-tools/latest/bin/avdmanager" /usr/local/bin/avdmanager \
+    && adb --version >/dev/null
+
+WORKDIR /src
+CMD ["bash"]
+
+# ---------------------------------------------------------------------------
+# A real build, used to prove the image above actually works and to produce an
+# APK. Not published — it carries a copy of the sources.
+# ---------------------------------------------------------------------------
+FROM sdk AS build
+
+WORKDIR /src
+
+# The wrapper and dependency declarations first, so editing game code does not
+# re-download Gradle and the whole dependency graph.
+COPY Android-Version/Game2048/gradle/ ./gradle/
+COPY Android-Version/Game2048/gradlew ./gradlew
+COPY Android-Version/Game2048/settings.gradle.kts Android-Version/Game2048/build.gradle.kts Android-Version/Game2048/gradle.properties ./
+RUN ./gradlew --no-daemon --version >/dev/null
+
+COPY Android-Version/Game2048/app/ ./app/
+
+# No daemon: it would outlive the RUN layer for nothing and only inflate the
+# image. Tests run here too, so a broken build cannot yield a green image.
+RUN ./gradlew --no-daemon assembleDebug testDebugUnitTest
+
+# ---------------------------------------------------------------------------
+# Extraction target. `--output` against this stage writes the APK to the host
+# without running a container or publishing anything.
+# ---------------------------------------------------------------------------
+FROM scratch AS apk
+COPY --from=build /src/app/build/outputs/apk/debug/app-debug.apk /app-debug.apk

--- a/scripts/validate-repository.mjs
+++ b/scripts/validate-repository.mjs
@@ -11,6 +11,7 @@ const requiredFiles = [
     ".devcontainer/devcontainer.json",
     ".devcontainer/devcontainer-lock.json",
     "Dockerfile",
+    "Dockerfile.android",
     ".github/PULL_REQUEST_TEMPLATE.md",
     ".pre-commit-config.yaml",
     "AGENTS.md",


### PR DESCRIPTION
## What

Adds `Dockerfile.android` and a `docker-android` CI job, so the Android client builds without Android Studio and the SDK toolbox is published to GHCR.

```bash
# toolbox: mount a checkout and build against it
docker run --rm -v "$PWD:/src" -w /src/Android-Version/Game2048 \
    ghcr.io/hoangsonww/2048-game-android:latest ./gradlew assembleDebug

# one-shot: extract a freshly built debug APK, no container started
docker buildx build -f Dockerfile.android --target apk --output out .
```

## Three stages, for three different reasons

| Stage | Contains | Published |
| --- | --- | --- |
| `sdk` | JDK 17 + Android SDK 34 + build-tools 34.0.0, **no project sources** | yes |
| `build` | `sdk` plus the client; runs `assembleDebug testDebugUnitTest` | no |
| `apk` | `FROM scratch`, just the APK, so `--output` can extract it | no |

Keeping sources out of `sdk` is what makes it reusable against any checkout, including a contributor's dirty working tree.

## Why `eclipse-temurin:17-jdk-jammy` specifically

`gradle/gradle-daemon-jvm.properties` pins `toolchainVendor=ADOPTIUM` and `toolchainVersion=17`. Temurin *is* Adoptium 17, so Gradle uses the JDK already in the image instead of downloading a toolchain from foojay at build time.

## Verifying vs. proving

The job does both, and the difference is the point:

- **Verify the toolchain** — `java -version` is 17, `adb`/`sdkmanager` resolve, `platforms/android-34` and `build-tools/34.0.0` exist. Runs under `bash -lc`, so it also proves the `/usr/local/bin` symlinks survive a login shell resetting `PATH`.
- **Prove it builds** — actually build the APK *from* that image, with the unit tests included.

Asserting `adb` exists proves a binary is present. It does not prove the image can still build the project — an SDK bump or a Gradle bump breaks the build while leaving every binary check green. The APK is then checked for a real `AndroidManifest.xml`, because a truncated file is still a file, and uploaded as a workflow artifact.

## Architecture

`linux/amd64` only. Google ships the Android command-line tools and build-tools for Linux as x86_64 binaries, so an arm64 image would build cleanly and then fail at `aapt2` and `d8` — worse than not offering it.

## iOS

Absent, and not a gap that can be closed. Docker containers are Linux; Xcode is macOS-only with no Linux build; Apple's licence forbids redistributing Xcode. Any one of the three is fatal on its own. iOS builds always require a macOS host, which is why the `ios` job runs on `macos-15`.

## Verification

`npm run check` passes. The image build itself is unverified locally — the local Docker daemon is still blocked on a privileged-helper prompt — so this run is its first real build, same as the previous Docker PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014jMpBbpzsiUWE21B9WvkRF