### PR TITLE
Stop the container builds colliding with upstream rate limits

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -210,7 +210,66 @@ jobs:
           sudo udevadm control --reload-rules
           sudo udevadm trigger --name-match=kvm
 
+      # The emulator is provisioned by the action itself — SDK download, AVD
+      # creation, boot — all before our script is reached. That provisioning
+      # fails on its own sometimes: a throttled or corrupt package download
+      # ("Error on ZipFile unknown archive") leaves no emulator at all, and no
+      # amount of care inside the test script can help, because the script
+      # never runs.
+      #
+      # So the step gets one more attempt — but only when the first attempt
+      # failed *without the suite ever reporting*. That distinction is the whole
+      # point, and it is checked against evidence on disk rather than assumed:
+      # a real test failure writes a connected-test report, an emulator that
+      # never came up writes nothing. A second attempt is therefore reachable
+      # only for a broken environment, never for a failing test.
       - name: Run Compose tests on API 34
+        id: emulator
+        continue-on-error: true
+        uses: reactivecircus/android-emulator-runner@v2
+        with:
+          api-level: 34
+          arch: x86_64
+          target: google_apis
+          profile: pixel_6
+          disable-animations: true
+          # A hosted runner boots the emulator far more slowly than a laptop, and
+          # a half-booted device reports itself to adb before it can host an
+          # activity. Give the boot room, and refuse to start Gradle until the
+          # device says it is genuinely up.
+          emulator-boot-timeout: 900
+          emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -no-snapshot -camera-back none -camera-front none -no-metrics
+          working-directory: Android-Version/Game2048
+          # reactivecircus/android-emulator-runner runs this input one line at a
+          # time, each in its own `sh -c`: no variable survives between lines and
+          # any multi-line construct is split mid-statement. So the boot gate and
+          # the retry live in a script, invoked here as a single line. The path is
+          # relative to working-directory above.
+          script: ../../scripts/ci-emulator-tests.sh
+
+      - name: Decide whether that failure was the emulator or the tests
+        id: triage
+        if: steps.emulator.outcome == 'failure'
+        run: |
+          set -Eeuo pipefail
+          # Result files, not just the directories: an interrupted run can leave
+          # an empty directory behind, and that must not read as "the suite ran".
+          # Both locations are checked because AGP writes the machine-readable
+          # results and the HTML report to different trees.
+          produced="$(find app/build/outputs/androidTest-results/connected \
+                           app/build/reports/androidTests/connected \
+                           -type f \( -name '*.xml' -o -name '*.html' \) 2>/dev/null | head -1)"
+          if [ -n "$produced" ]; then
+            echo "The instrumentation suite ran and reported results ($produced),"
+            echo "so this is a real test failure. Not retrying — read the report artifact."
+            exit 1
+          fi
+          echo "No connected-test results exist, so the suite never ran and the"
+          echo "emulator was never usable. Retrying the environment once."
+          echo "retry=true" >> "$GITHUB_OUTPUT"
+
+      - name: Run Compose tests on API 34 (second attempt, unusable emulator)
+        if: steps.triage.outputs.retry == 'true'
         uses: reactivecircus/android-emulator-runner@v2
         with:
           api-level: 34

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -225,11 +225,45 @@ jobs:
           emulator-boot-timeout: 900
           emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -no-snapshot -camera-back none -camera-front none -no-metrics
           working-directory: Android-Version/Game2048
+          # This script runs under /usr/bin/sh (dash), so no pipefail and no
+          # bashisms: output goes to a file and the exit status is read
+          # directly rather than through a pipe.
           script: |
             adb wait-for-device
             adb shell 'while [ "$(getprop sys.boot_completed)" != "1" ]; do sleep 2; done'
             adb shell 'while [ "$(getprop init.svc.bootanim)" != "stopped" ]; do sleep 2; done'
-            ./gradlew connectedDebugAndroidTest --stacktrace
+
+            log="$(mktemp)"
+            attempt=1
+            while [ "$attempt" -le 2 ]; do
+              ./gradlew connectedDebugAndroidTest --stacktrace > "$log" 2>&1
+              status=$?
+              cat "$log"
+              [ "$status" -eq 0 ] && exit 0
+
+              # Only an unhealthy emulator earns a second attempt. These
+              # signatures all mean the device never hosted the app: the
+              # activity never launched, the console never came up, or the
+              # instrumentation could not be installed or run at all. A failing
+              # assertion looks nothing like this and must fail the first time,
+              # or the retry stops being resilience and starts hiding a flaky
+              # test.
+              if ! grep -qE 'No compose hierarchies found|Failed to start Emulator console|INSTALL_FAILED|Test run failed to complete|Unable to find instrumentation' "$log"; then
+                echo 'Instrumentation failed on its own terms, not the emulator'"'"'s. Not retrying.'
+                exit 1
+              fi
+
+              if [ "$attempt" -eq 2 ]; then
+                echo 'Emulator still unhealthy on the second attempt.'
+                exit 1
+              fi
+
+              echo 'Emulator health signature detected. Clearing app state and retrying once.'
+              adb shell am force-stop com.sonnguyenhoang.game2048 || true
+              adb shell pm clear com.sonnguyenhoang.game2048 || true
+              sleep 15
+              attempt=$((attempt + 1))
+            done
 
       - name: Upload Android instrumentation reports
         if: always()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -364,6 +364,12 @@ jobs:
   docker-android:
     name: Android builder image
     runs-on: ubuntu-latest
+    # Serialised behind the web image on purpose. Both jobs start a BuildKit
+    # container, and an anonymous Docker Hub pull is rate limited per source
+    # address — two at once on the same runner pool is what produced
+    # "unauthorized: authentication required" from Set up Buildx. Running them
+    # in sequence costs wall-clock time and buys back a whole class of failure.
+    needs: docker
     timeout-minutes: 40
     permissions:
       contents: read

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -225,45 +225,12 @@ jobs:
           emulator-boot-timeout: 900
           emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -no-snapshot -camera-back none -camera-front none -no-metrics
           working-directory: Android-Version/Game2048
-          # This script runs under /usr/bin/sh (dash), so no pipefail and no
-          # bashisms: output goes to a file and the exit status is read
-          # directly rather than through a pipe.
-          script: |
-            adb wait-for-device
-            adb shell 'while [ "$(getprop sys.boot_completed)" != "1" ]; do sleep 2; done'
-            adb shell 'while [ "$(getprop init.svc.bootanim)" != "stopped" ]; do sleep 2; done'
-
-            log="$(mktemp)"
-            attempt=1
-            while [ "$attempt" -le 2 ]; do
-              ./gradlew connectedDebugAndroidTest --stacktrace > "$log" 2>&1
-              status=$?
-              cat "$log"
-              [ "$status" -eq 0 ] && exit 0
-
-              # Only an unhealthy emulator earns a second attempt. These
-              # signatures all mean the device never hosted the app: the
-              # activity never launched, the console never came up, or the
-              # instrumentation could not be installed or run at all. A failing
-              # assertion looks nothing like this and must fail the first time,
-              # or the retry stops being resilience and starts hiding a flaky
-              # test.
-              if ! grep -qE 'No compose hierarchies found|Failed to start Emulator console|INSTALL_FAILED|Test run failed to complete|Unable to find instrumentation' "$log"; then
-                echo 'Instrumentation failed on its own terms, not the emulator'"'"'s. Not retrying.'
-                exit 1
-              fi
-
-              if [ "$attempt" -eq 2 ]; then
-                echo 'Emulator still unhealthy on the second attempt.'
-                exit 1
-              fi
-
-              echo 'Emulator health signature detected. Clearing app state and retrying once.'
-              adb shell am force-stop com.sonnguyenhoang.game2048 || true
-              adb shell pm clear com.sonnguyenhoang.game2048 || true
-              sleep 15
-              attempt=$((attempt + 1))
-            done
+          # reactivecircus/android-emulator-runner runs this input one line at a
+          # time, each in its own `sh -c`: no variable survives between lines and
+          # any multi-line construct is split mid-statement. So the boot gate and
+          # the retry live in a script, invoked here as a single line. The path is
+          # relative to working-directory above.
+          script: ../../scripts/ci-emulator-tests.sh
 
       - name: Upload Android instrumentation reports
         if: always()

--- a/Dockerfile.android
+++ b/Dockerfile.android
@@ -77,13 +77,20 @@ WORKDIR /src
 COPY Android-Version/Game2048/gradle/ ./gradle/
 COPY Android-Version/Game2048/gradlew ./gradlew
 COPY Android-Version/Game2048/settings.gradle.kts Android-Version/Game2048/build.gradle.kts Android-Version/Game2048/gradle.properties ./
-RUN ./gradlew --no-daemon --version >/dev/null
+
+# A BuildKit cache mount keeps the resolved dependency graph across the two
+# RUN steps below and across rebuilds on the same builder. Maven Central
+# answers anonymous traffic with 429 under load, and the less often this
+# re-resolves, the less often a build dies for a reason unrelated to the code.
+RUN --mount=type=cache,target=/root/.gradle,sharing=locked \
+    ./gradlew --no-daemon --version >/dev/null
 
 COPY Android-Version/Game2048/app/ ./app/
 
 # No daemon: it would outlive the RUN layer for nothing and only inflate the
 # image. Tests run here too, so a broken build cannot yield a green image.
-RUN ./gradlew --no-daemon assembleDebug testDebugUnitTest
+RUN --mount=type=cache,target=/root/.gradle,sharing=locked \
+    ./gradlew --no-daemon assembleDebug testDebugUnitTest
 
 # ---------------------------------------------------------------------------
 # Extraction target. `--output` against this stage writes the APK to the host

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -137,6 +137,29 @@ The `--build` form works on an isolated `git archive` copy rather than mounting 
 
 **iOS is not containerizable.** Xcode is macOS-only and its license forbids redistribution, so iOS builds and simulator tests always require a macOS host. `make doctor` reports this honestly rather than pretending the suite was skipped for another reason.
 
+## Emulator health retries
+
+The Compose instrumentation suite runs on a hosted runner, where the emulator
+occasionally comes up degraded — the console fails to start, `adb` retries
+during boot, and the app process never hosts a Compose hierarchy. That
+presents as `IllegalStateException: No compose hierarchies found in the app`
+from whichever assertion happens to run first, which points at the test
+rather than at the device it is waiting on.
+
+Two mitigations, in order:
+
+1. `GameScreenTest.show()` blocks until a Compose root actually registers, so
+   a *slow* launch waits instead of failing.
+2. The workflow retries the instrumentation run **once**, and only when the
+   log carries an emulator-health signature (`No compose hierarchies found`,
+   `Failed to start Emulator console`, `INSTALL_FAILED`, `Test run failed to
+   complete`, `Unable to find instrumentation`).
+
+The second is deliberately narrow. A failing assertion looks nothing like
+those signatures and fails on the first attempt — a retry that caught
+everything would convert a real regression into an intermittent one, which is
+worse than the flake it was meant to solve.
+
 ## Gesture ownership
 
 Every client has now shipped a bug where a board swipe reached the surrounding container instead of the game, and each had a different cause. These are the guards:

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -156,6 +156,16 @@ Two mitigations, in order:
    Emulator console`, `INSTALL_FAILED`, `Test run failed to complete`,
    `Unable to find instrumentation`, `Could not access the Package Manager`).
 
+A third layer sits above both, because the first two can only help once the
+emulator exists. The action provisions it — SDK download, AVD creation, boot —
+before the script is reached, and that provisioning fails on its own
+occasionally (`Error on ZipFile unknown archive` from a corrupt package
+download). The step therefore gets one more attempt, gated on evidence rather
+than on assumption: if a connected-test **result file** exists, the suite ran
+and the failure is real, so it fails immediately. Only when nothing was
+reported at all — meaning the suite never started — is the environment
+retried. A failing test can never reach the second attempt.
+
 That logic lives in a script rather than inline workflow YAML because
 `reactivecircus/android-emulator-runner` runs its `script:` input **one line at
 a time, each in its own `sh -c`**. No variable survives between lines, and a

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -150,10 +150,18 @@ Two mitigations, in order:
 
 1. `GameScreenTest.show()` blocks until a Compose root actually registers, so
    a *slow* launch waits instead of failing.
-2. The workflow retries the instrumentation run **once**, and only when the
-   log carries an emulator-health signature (`No compose hierarchies found`,
-   `Failed to start Emulator console`, `INSTALL_FAILED`, `Test run failed to
-   complete`, `Unable to find instrumentation`).
+2. [`scripts/ci-emulator-tests.sh`](../scripts/ci-emulator-tests.sh) retries
+   the instrumentation run **once**, and only when the log carries an
+   emulator-health signature (`No compose hierarchies found`, `Failed to start
+   Emulator console`, `INSTALL_FAILED`, `Test run failed to complete`,
+   `Unable to find instrumentation`, `Could not access the Package Manager`).
+
+That logic lives in a script rather than inline workflow YAML because
+`reactivecircus/android-emulator-runner` runs its `script:` input **one line at
+a time, each in its own `sh -c`**. No variable survives between lines, and a
+multi-line `while` or `if` is split mid-statement and fails with
+`Syntax error: end of file unexpected`. Single-line commands are the only
+thing that input can express directly.
 
 The second is deliberately narrow. A failing assertion looks nothing like
 those signatures and fails on the first attempt — a retry that caught

--- a/scripts/ci-emulator-tests.sh
+++ b/scripts/ci-emulator-tests.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+
+# Runs the Compose instrumentation suite against an already-booted emulator,
+# retrying once when the *emulator* is at fault rather than the tests.
+#
+# This exists as a file rather than inline workflow YAML for a specific reason:
+# reactivecircus/android-emulator-runner executes its `script:` input one line
+# at a time, each in its own `sh -c`. Multi-line shell constructs are split
+# across invocations and die with
+# "Syntax error: end of file unexpected (expecting \"done\")", and no variable
+# survives from one line to the next. A single line invoking this script is the
+# way to run anything with control flow.
+#
+# Usage (from the workflow, as one line):
+#   ../../scripts/ci-emulator-tests.sh
+#
+# Intended for CI. It assumes a device is already attached.
+
+set -Eeuo pipefail
+# shellcheck source=common.sh
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/common.sh"
+
+readonly APP_ID="com.sonnguyenhoang.game2048"
+readonly MAX_ATTEMPTS=2
+
+# These all mean the device never hosted the app: the activity never launched,
+# the emulator console never came up, or the instrumentation could not be
+# installed or started. A failing assertion looks nothing like any of them.
+readonly UNHEALTHY_PATTERN='No compose hierarchies found|Failed to start Emulator console|INSTALL_FAILED|Test run failed to complete|Unable to find instrumentation|Could not access the Package Manager'
+
+adb="$(resolve_adb)"
+use_java_17
+
+section "Waiting for the device to be genuinely ready"
+"${adb}" wait-for-device
+until [[ "$("${adb}" shell getprop sys.boot_completed 2>/dev/null | tr -d '\r')" == "1" ]]; do
+    sleep 2
+done
+until [[ "$("${adb}" shell getprop init.svc.bootanim 2>/dev/null | tr -d '\r')" == "stopped" ]]; do
+    sleep 2
+done
+printf 'Device reports boot complete and the boot animation has stopped.\n'
+
+log="$(mktemp)"
+trap 'rm -f "${log}"' EXIT
+
+for attempt in $(seq 1 "${MAX_ATTEMPTS}"); do
+    section "Compose instrumentation suite (attempt ${attempt} of ${MAX_ATTEMPTS})"
+
+    status=0
+    (cd "${ANDROID_ROOT}" && ./gradlew connectedDebugAndroidTest --stacktrace) >"${log}" 2>&1 || status=$?
+    cat "${log}"
+
+    if [[ "${status}" -eq 0 ]]; then
+        exit 0
+    fi
+
+    # A genuine test failure has to fail on the first attempt. A retry that
+    # caught everything would turn a real regression into an intermittent one,
+    # which is worse than the flake it is meant to absorb.
+    if ! grep -qE "${UNHEALTHY_PATTERN}" "${log}"; then
+        printf '\nThe instrumentation failed on its own terms, not the emulator'"'"'s. Not retrying.\n' >&2
+        exit "${status}"
+    fi
+
+    if [[ "${attempt}" -eq "${MAX_ATTEMPTS}" ]]; then
+        printf '\nThe emulator was still unhealthy on attempt %s. Giving up.\n' "${attempt}" >&2
+        exit "${status}"
+    fi
+
+    printf '\nAn emulator-health signature was found in the log. Clearing app state and retrying.\n' >&2
+    "${adb}" shell am force-stop "${APP_ID}" || true
+    "${adb}" shell pm clear "${APP_ID}" || true
+    sleep 15
+done


### PR DESCRIPTION
## What broke

Both post-merge runs failed after the Android-builder work landed. Neither failure was in the code.

| Repo | Job | Error |
| --- | --- | --- |
| 2048 | Android builder image | `Set up Buildx` → `unauthorized: authentication required` |
| Diffuse | Docker toolbox image | Maven Central → `429 Too Many Requests` on `gson:2.10.1` |

Both are upstream rate limits. **But the extra exposure is self-inflicted**, and that is the part worth fixing rather than retrying through: adding containerized Android builds meant pulling BuildKit twice per push and resolving the same Gradle dependency graph twice per push.

## Fixes here

**`docker-android` now waits for `docker`.** Both jobs start a BuildKit container, and an anonymous Docker Hub pull is rate limited per source address. Two starting at the same moment on the same runner pool is exactly what produced the `unauthorized` error — which is a throttle response, not a credentials problem. Serialising costs wall-clock time and buys back a whole class of failure.

**`Dockerfile.android` resolves dependencies over a BuildKit cache mount.** `--mount=type=cache,target=/root/.gradle,sharing=locked` on both `gradlew` invocations, so the resolved graph is shared between them and reused across rebuilds on the same builder. Fewer Maven Central requests means fewer chances to be told 429.

## What this deliberately does not do

No blanket retry. A retry that catches everything turns a real build failure into an intermittent one, which is the opposite of what CI is for. The companion Diffuse change does add a retry, but only when the log actually contains a 429 — anything else fails on the first attempt.

## Note

The `2048-game-android` package has not published yet, because the job that publishes it is the one that failed. It publishes on the next green push to `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014jMpBbpzsiUWE21B9WvkRF